### PR TITLE
feat: set-version option to set version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 os: linux
-dist: trusty
+dist: focal
 
 cache:
   directories:

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ With that setup the file is updated when `npm start` and `npm build` are run.
 | --file  | relative location of the output file (based on the root directory) |  ./src/_version.ts  |  false  |
 | --git  | relative location of the folder containing the .git folder (based on the root directory) |  .  |
 | --pnpm | PNPM has a different folder structure, resulting in a different root level. Add this if you use PNPM to install your dependencies. If package.json is not found at the expected PNPM path, it will fall back to the default one. This setting is ignored if `--root` is an absolute path. | false |
+| --set-version | Set this to override the value of the version string fetched from package.json (set in `version` property) |  |
 
 ## Receiving the versions
 
@@ -68,11 +69,9 @@ export class AppComponent {
 }
 ```
 
-> backward compatibility with previous version is guarantee
-
 The file will export an object with following variables:
 
-* **version** is the version from the packages.json (e.g. v1.0.0)
+* **version** is the version from packages.json (or value of `set-version` option if set)
 * **name** is the name from the packages.json (e.g. 'sample-app')
 * **description** is the description from the packages.json
 * **versionDate** is the timestamp in ISO format when the compilation/package started.

--- a/dist/index.js
+++ b/dist/index.js
@@ -50,13 +50,19 @@ const outputFile = argv.hasOwnProperty('file') ? argv.file : path.join('src', '_
 const versionFile = path.join(projectFolder, outputFile);
 
 // pull version from package.json
-const pkg = require(packageFile); 
-const appVersion = pkg.version;
-const appName = pkg.name;
-const appDescription = pkg.description;
+const pkg = require(packageFile);
+const appName = pkg.name || '';
+const appDescription = pkg.description || '';
+
+let appVersion = pkg.version || '';
 
 console.log('[TsAppVersion] ' + colors.green('Application version (from package.json): ') + colors.yellow(appVersion));
 console.log('[TsAppVersion] ' + colors.green('Application name (from package.json): ') + colors.yellow(appName));
+
+if (argv.hasOwnProperty('set-version')) {
+    appVersion = argv['set-version']
+    console.log('[TsAppVersion] Setting fixed version ' + appVersion + ' from command option.');
+}
 
 let src = `export interface TsAppVersion {
     version: string;

--- a/dist/index.js
+++ b/dist/index.js
@@ -125,7 +125,7 @@ if (enableGit) {
         }
         console.log('[TsAppVersion] ' + colors.green('Long Git version: ') + colors.yellow(versionWithHash));
         src += `    versionLong: '${versionWithHash}',\n`;
-        if (info.hasOwnProperty('tag')) {
+        if (info.hasOwnProperty('tag') && info.tag !== null) {
             console.log('[TsAppVersion] ' + colors.green('Git tag: ') + colors.yellow(info.tag));
             src += `    gitTag: '${info.tag}',\n`;
         }


### PR DESCRIPTION
The option `--set-version` may be used to set a custom version (e.g. `npx ts-appversion --set-version=1.0.0`).
This is useful for using semantic-release.